### PR TITLE
Update to v0.15.13

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,7 +5,4 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
-zip_keys:
-- - cdt_name
-  - docker_image
+- quay.io/condaforge/linux-anvil-cos7-x86_64

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@main
+        uses: conda-forge/automerge-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@master
+        uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@main
+        uses: conda-forge/webservices-dispatch-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -53,7 +55,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prefect" %}
-{% set version = "0.15.11" %}
+{% set version = "0.15.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 091cc78ba3f7ec20a06dcdaf6fc5f0f79b494a98b93b7693bbe7d1ef1dc81c18
+  sha256: 192d00c9bdab2cdfb2b985f6e9814cd6c38001165e9f60fe6966da69bebe7c11
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prefect" %}
-{% set version = "0.15.10" %}
+{% set version = "0.15.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a11d22ed609a1eae29925aea9f3d1ac78a84df00a86503979ff1512d57233d5a
+  sha256: 091cc78ba3f7ec20a06dcdaf6fc5f0f79b494a98b93b7693bbe7d1ef1dc81c18
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - marshmallow >=3.0.0b19
     - marshmallow-oneofschema >=2.0.0b2
     - mypy_extensions >=0.4.0
+    - packaging >= 20.0
     - pendulum >=2.0.4
     - python-dateutil >2.7.3
     - pyyaml >=3.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - marshmallow >=3.0.0b19
     - marshmallow-oneofschema >=2.0.0b2
     - mypy_extensions >=0.4.0
-    - packaging >= 20.0
+    - packaging >=20.0
     - pendulum >=2.0.4
     - python-dateutil >2.7.3
     - pyyaml >=3.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "prefect" %}
-{% set version = "0.15.12" %}
+{% set version = "0.15.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 192d00c9bdab2cdfb2b985f6e9814cd6c38001165e9f60fe6966da69bebe7c11
+  sha256: a4c2c63a2f950cfacf7b10710b6c5cadbdc55033503212b54a8397f0b6b17d8f
 
 build:
   noarch: python


### PR DESCRIPTION
Merging the conda-forge recipe, which is directly maintained by upstream. Our custom log patch can be removed as not required anymore.